### PR TITLE
Update/fix link to create-certificate-authority.md directly

### DIFF
--- a/docs/PRESENTATION.md
+++ b/docs/PRESENTATION.md
@@ -78,7 +78,7 @@
       - You can use Active directory or single sign-on instead
   - Create a CA (certificate authority)
     - Guides
-      - [docs/create-certificate-authority.md](docs/create-certificate-authority.md)
+      - [docs/create-certificate-authority.md](create-certificate-authority.md)
       - [AWS Docs](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/client-authentication.html)
     - Create a server certificate and key
     - Create client cert and key


### PR DESCRIPTION
Update link to create-certificate-authority.md directly, not relativelly through docs, as it link from same folder and otherwise it attaches docs/docs twice